### PR TITLE
Add support for multiple data tables

### DIFF
--- a/Converter/src/Run3AODConverter.h
+++ b/Converter/src/Run3AODConverter.h
@@ -10,9 +10,15 @@
 #ifndef o2_framework_run2_Run3AODConverter_H_INCLUDED
 #define o2_framework_run2_Run3AODConverter_H_INCLUDED
 
-#include <ostream>
+#include <memory>
 
 class TTree;
+
+namespace arrow {
+namespace io {
+class OutputStream;
+}
+}
 
 namespace o2
 {
@@ -25,7 +31,7 @@ namespace run2
 struct Run3AODConverter {
   // Helper to return a callback which is able to conver a Run2 ESD file to an
   // Arrow Table which then gets streamed to an ostream.
-  static void convert(TTree *tESD, std::ostream &);
+  static void convert(TTree *tESD, std::shared_ptr<arrow::io::OutputStream> s);
 };
 
 } // namespace run2

--- a/Converter/src/run2ESD2Run3AOD.cxx
+++ b/Converter/src/run2ESD2Run3AOD.cxx
@@ -1,4 +1,8 @@
 #include "Run3AODConverter.h"
+#include <arrow/io/buffered.h>
+#include <arrow/util/io-util.h>
+#include <arrow/ipc/writer.h>
+
 #include <iostream>
 #include <memory>
 #include <TFile.h>
@@ -16,7 +20,11 @@ main(int argc, char **argv) {
   for (size_t i = 1; i < argc; ++i) {
     auto infile = std::make_unique<TFile>(argv[i]);
     TTree* tEsd = (TTree*)infile->Get("esdTree");
-    o2::framework::run2::Run3AODConverter::convert(tEsd, std::cout);
+    std::shared_ptr<arrow::io::OutputStream> rawStream(new arrow::io::StdoutStream);
+    std::shared_ptr<arrow::io::BufferedOutputStream> stream;
+    arrow::io::BufferedOutputStream::Create(1000000, arrow::default_memory_pool(), rawStream, &stream);
+    o2::framework::run2::Run3AODConverter::convert(tEsd, stream);
+    stream->Close();
   }
   return 0;
 }

--- a/Run2DataModel/src/AliESDEvent.cxx
+++ b/Run2DataModel/src/AliESDEvent.cxx
@@ -564,15 +564,15 @@ void AliESDEvent::ResetStdContent()
   if(fSPDPileupVertices)fSPDPileupVertices->Delete();
   if(fTrkPileupVertices)fTrkPileupVertices->Delete();
   fTracksConnected = kFALSE;
-  if(fTracks)fTracks->Delete();
+  if(fTracks)fTracks->Clear("C");
   if(fMuonTracks)fMuonTracks->Clear("C");
   if(fMuonClusters)fMuonClusters->Clear("C");
   if(fMuonPads)fMuonPads->Clear("C");
   if(fMuonGlobalTracks)fMuonGlobalTracks->Clear("C");     // AU
   if(fPmdTracks)fPmdTracks->Delete();
-  if(fTrdTracks)fTrdTracks->Delete();
-  if(fTrdTracklets)fTrdTracklets->Delete();
-  if(fV0s)fV0s->Delete();
+  if(fTrdTracks)fTrdTracks->Clear("C");
+  if(fTrdTracklets)fTrdTracklets->Clear("C");
+  if(fV0s)fV0s->Clear("C");
   if(fCascades)fCascades->Delete();
   if(fKinks)fKinks->Delete();
   if(fCaloClusters)fCaloClusters->Delete();

--- a/scripts/pythonReader.py
+++ b/scripts/pythonReader.py
@@ -3,8 +3,21 @@ import pyarrow as pa
 import matplotlib.pyplot as plt
 import sys
 
-reader = pa.ipc.open_stream(pa.PythonFile(sys.stdin))
-t = reader.read_next_batch()
-df = t.to_pandas(zero_copy_only=True)
-h1 = df.hist(column='fSigned1Pt', bins=100)
+tables = {}
+
+try:
+  while True:
+    reader = pa.ipc.open_stream(pa.PythonFile(sys.stdin))
+    t = reader.read_all()
+    print t.schema.metadata
+    tables[t.schema.metadata["description"]] = t
+except Exception,e:
+  pass
+
+# A couple of plots to 
+df = tables["TRACKPAR"].to_pandas(zero_copy_only=True)
+h1 = df.hist(column='fSigned1Pt', bins=100, range=[-30,30])
 plt.savefig('figure.pdf')
+df2 = tables["CALO"].to_pandas(zero_copy_only=True)
+h2 = df2.hist(column='fAmplitude', bins=100, range=[0, 0.7])
+plt.savefig('figure2.pdf')


### PR DESCRIPTION
Both the converter and the python script now have some sort of
support for handling all the tables in our AOD format.
For each ESD file we convert it into the Arrow tables,
attach some metadata to distinguish between them and finally
stream them through stdout. On the receiving side we
use the metadata to assign each table a mnemonic name.