### PR TITLE
Fix issue with unaligned writes

### DIFF
--- a/Converter/src/Run3AODConverter.cxx
+++ b/Converter/src/Run3AODConverter.cxx
@@ -341,6 +341,13 @@ void Run3AODConverter::convert(TTree* tEsd, std::shared_ptr<arrow::io::OutputStr
       if (batch == nullptr) {
         break;
       }
+      // Align the stream to 8 bytes, as requested by Arrow
+      int64_t pos;
+      stream->Tell(&pos);
+      if (pos % 8 != 0) {
+        int64_t extra;
+        stream->Write(&extra, 8 - (pos % 8));
+      }
       auto outStatus = writer->WriteRecordBatch(*batch);
     }
     if (writer->Close().ok() != true) {


### PR DESCRIPTION
Arrow requires each data structure to be 8 bytes aligned, so it could
happen when writing to a stream multiple tables that from the second
onwards they could get misaligned. This inserts the needed extra
padding.