### PR TITLE
Workaround missing string_view header

### DIFF
--- a/Run2DataModel/src/AliVVertex.h
+++ b/Run2DataModel/src/AliVVertex.h
@@ -8,6 +8,7 @@
 //     Author: A. Dainese
 //-------------------------------------------------------------------------
 
+#include <string_view>
 #include <TNamed.h>
 
 class AliVVertex: public TNamed {


### PR DESCRIPTION
This is most likely a problem in ROOT, actually, but this should
work it around.